### PR TITLE
Add a perhaps overcomplicated "npm run release" one-liner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glif-mcp-server",
-  "version": "0.1.0",
+  "version": "0.9.1",
   "description": "Run AI magic workflows from glif.app",
   "private": true,
   "type": "module",
@@ -21,7 +21,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "logs:claude": "tail -f -n 5 ~/Library/Logs/Claude/**glif*.log",
-    "logs:claude_all": "tail -f -n 5 ~/Library/Logs/Claude/**.log"
+    "logs:claude_all": "tail -f -n 5 ~/Library/Logs/Claude/**.log",
+    "release": "VERSION=$(jq -r .version package.json) && git tag v$VERSION && git push origin --tags && gh release create v$VERSION --fail-on-no-commits --generate-notes"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glif-mcp-server",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Run AI magic workflows from glif.app",
   "private": true,
   "type": "module",
@@ -22,7 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "logs:claude": "tail -f -n 5 ~/Library/Logs/Claude/**glif*.log",
     "logs:claude_all": "tail -f -n 5 ~/Library/Logs/Claude/**.log",
-    "release": "VERSION=$(jq -r .version package.json) && git tag v$VERSION && git push origin --tags && gh release create v$VERSION --fail-on-no-commits --generate-notes"
+    "release": "BRANCH=$(git branch --show-current) && [ \"$BRANCH\" = \"main\" ] || (echo \"Error: Must be on main branch to release\" && exit 1) && VERSION=$(jq -r .version package.json) && REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) && git tag v$VERSION && git push origin --tags && PREV_TAG=$(git describe --tags --abbrev=0 v$VERSION^ 2>/dev/null || echo '') && NOTES=$(git log --pretty=format:\"- [%h](https://github.com/$REPO/commit/%H) %s\" ${PREV_TAG:+$PREV_TAG..}HEAD) && gh release create v$VERSION --fail-on-no-commits --notes \"$NOTES\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.6.1",


### PR DESCRIPTION
- abort if not main
- create git tag from `package.json`
- compile reasonably cool release notes
- run `gh release` to create release

then this should kick off the `publish` GitHub action which will push to npm. I don't think that forcibly checks if build is valid, so don't merge PRs that aren't green pls