### PR TITLE
Disable bot-related tools by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ Info about authenticated user's glifs:
 - `my_liked_glifs` - current user's liked glifs
 - `my_runs` - current user's public runs
 
+## MCP registries
+
+[![smithery badge](https://smithery.ai/badge/@glifxyz/glif-mcp-server)](https://smithery.ai/server/@glifxyz/glif-mcp-server)
+
+<a href="https://glama.ai/mcp/servers/gwrql5ibq2">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/gwrql5ibq2/badge" alt="Glif MCP server" />
+</a>
+
 ## Development
 
 Install dependencies:
@@ -198,16 +206,6 @@ The Inspector will provide a URL to access debugging tools in your browser.
 
 You can also look at the glif-mcp logs inside the Claude logs directy if you're using Claude Desktop.
 
-## MCP registries
-
-[![smithery badge](https://smithery.ai/badge/@glifxyz/glif-mcp-server)](https://smithery.ai/server/@glifxyz/glif-mcp-server)
-
-<a href="https://glama.ai/mcp/servers/gwrql5ibq2">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/gwrql5ibq2/badge" alt="Glif MCP server" />
-</a>
-
-## Development
-
 ### Releasing a new version
 
 1. Edit `package.json` and `src/index.ts` and bump the version number
@@ -215,7 +213,6 @@ You can also look at the glif-mcp logs inside the Claude logs directy if you're 
 3. Commit and push your changes to GitHub and merge to main
 4. If you have [gh](https://cli.github.com/) installed, switch to main and run `npm run release` which will create a git tag for the new version, push that tag to github, and use `gh release create` to publish a new version with an automatically-generated changelog. If you don't have `gh`, you can do the above manually in the GitHub web UI
 5. A GitHub Action will use the `NPM_TOKEN` secret to publish it to NPM
-
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glifxyz/glif-mcp-server",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@glifxyz/glif-mcp-server",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glifxyz/glif-mcp-server",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Run AI magic workflows from glif.app",
   "license": "MIT",
   "author": "glifxyz",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ async function main() {
   const server = new Server(
     {
       name: "glif",
-      version: "0.9.8",
+      version: "0.9.9",
     },
     {
       capabilities: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -44,7 +44,6 @@ export type ToolGroup = {
 // Import core tools
 import * as glifInfo from "./glif-info.js";
 import * as runGlif from "./run-glif.js";
-import * as listBots from "./list-bots.js";
 
 // Import discovery tools
 import * as listFeaturedGlifs from "./list-featured-glifs.js";
@@ -57,9 +56,12 @@ import * as saveGlifAsTool from "./save-glif-as-tool.js";
 import * as removeGlifTool from "./remove-glif-tool.js";
 import * as removeAllGlifTools from "./remove-all-glif-tools.js";
 import * as listSavedGlifTools from "./list-saved-glif-tools.js";
-import * as saveBotSkillsAsTools from "./save-bot-skills-as-tools.js";
-import * as loadBot from "./load-bot.js";
-import * as showBotInfo from "./show-bot-info.js";
+
+// Bot tools - beta
+// import * as listBots from "./list-bots.js";
+// import * as saveBotSkillsAsTools from "./save-bot-skills-as-tools.js";
+// import * as loadBot from "./load-bot.js";
+// import * as showBotInfo from "./show-bot-info.js";
 
 // Tool groupings
 const CORE_TOOLS: ToolGroup = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -241,7 +241,7 @@ export function setupToolHandlers(server: Server) {
       }
     }
 
-    // Handle metaskill tools
+    // Handle metaskill tools (unless IGNORE_METASKILL_TOOLS)
     if (process.env.IGNORE_METASKILL_TOOLS !== "true") {
       const metaskillTool = METASKILL_TOOLS[request.params.name];
       if (metaskillTool) {

--- a/test/tools-saved-glifs.test.ts
+++ b/test/tools-saved-glifs.test.ts
@@ -84,6 +84,7 @@ describe("Tools with Saved Glifs", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     process.env.IGNORE_DISCOVERY_TOOLS = "true";
+    process.env.BOT_TOOLS = "true"; // Enable bot tools for tests
     sampleGlif1 = createSavedGlif("glif-123", 1);
     sampleGlif2 = createSavedGlif("glif-456", 2);
 
@@ -102,6 +103,7 @@ describe("Tools with Saved Glifs", () => {
 
   afterEach(() => {
     delete process.env.IGNORE_DISCOVERY_TOOLS;
+    delete process.env.BOT_TOOLS;
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
Not super useful yet and I find the LLMs preferring bot commands over glif commands

Arguably we should instead have a second MCP server just for bots! But in meantime hide behind `BOT_TOOLS=true` if you want to try it out
