### PR TITLE
Add `repository` URL to server.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,7 @@ This repo holds the registry metadata for the hosted server (see [`server.json`]
 
 ## Tools
 
-| Tool                                  | What it does                                                                                                                                                           |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `compose_project`                     | Create or continue a Glif project from a plain-language prompt. Glif picks the models and chains the steps itself. Returns a `job_id` immediately while the work runs. |
-| `get_job_status`                      | Poll a `compose_project` job; the completed poll carries the generated media.                                                                                          |
-| `get_project`                         | Project state, active job, recent messages, and assets.                                                                                                                |
-| `view_media`                          | Re-render already-generated media in the media viewer.                                                                                                                 |
-| `list_projects`                       | Recent projects owned by the caller.                                                                                                                                   |
-| `upload_file`                         | Upload an image, video, or audio file (URL or base64) for use as an input.                                                                                             |
-| `list_user_skills` / `get_user_skill` | The caller's own saved skills.                                                                                                                                         |
-| `whoami`                              | The signed-in account and its remaining credits.                                                                                                                       |
-
-Generated media comes back as `resource_link` blocks pointing at CDN URLs. Most work is one `compose_project` call — describe the whole thing, including a series of variations, in a single prompt rather than looping.
+`compose_project` does the work — describe what you want in plain language, including a whole series of variations, and Glif picks the models and chains the steps. It returns a `job_id` immediately; poll `get_job_status` for the media, which comes back as `resource_link` blocks pointing at CDN URLs. The rest are read and upload helpers. Call `tools/list` for the authoritative set, or see https://glif.app/mcp.
 
 Generation spends credits from the signed-in Glif account; read-only tools are free. See https://glif.app/pricing.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ This repo holds the registry metadata for the hosted server (see [`server.json`]
 > [!NOTE]
 > Looking for the old locally-run stdio server (npm `@glifxyz/glif-mcp-server`)? It's deprecated — the code is parked on the [`legacy-local-server`](https://github.com/glifxyz/glif-mcp-server/tree/legacy-local-server) branch.
 
+## Tools
+
+| Tool                                  | What it does                                                                                                                                                           |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compose_project`                     | Create or continue a Glif project from a plain-language prompt. Glif picks the models and chains the steps itself. Returns a `job_id` immediately while the work runs. |
+| `get_job_status`                      | Poll a `compose_project` job; the completed poll carries the generated media.                                                                                          |
+| `get_project`                         | Project state, active job, recent messages, and assets.                                                                                                                |
+| `view_media`                          | Re-render already-generated media in the media viewer.                                                                                                                 |
+| `list_projects`                       | Recent projects owned by the caller.                                                                                                                                   |
+| `upload_file`                         | Upload an image, video, or audio file (URL or base64) for use as an input.                                                                                             |
+| `list_user_skills` / `get_user_skill` | The caller's own saved skills.                                                                                                                                         |
+| `whoami`                              | The signed-in account and its remaining credits.                                                                                                                       |
+
+Generated media comes back as `resource_link` blocks pointing at CDN URLs. Most work is one `compose_project` call — describe the whole thing, including a series of variations, in a single prompt rather than looping.
+
+Generation spends credits from the signed-in Glif account; read-only tools are free. See https://glif.app/pricing.
+
 ## Install
 
 ### Claude (web / desktop)

--- a/server.json
+++ b/server.json
@@ -3,8 +3,13 @@
   "name": "app.glif/glif",
   "title": "Glif",
   "description": "Generate images, video, and audio with Glif's media-generation agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "websiteUrl": "https://glif.app/mcp",
+  "repository": {
+    "url": "https://github.com/glifxyz/glif-mcp-server",
+    "source": "github",
+    "id": "933381486"
+  },
   "icons": [
     { "src": "https://glif.app/glif-icon-512.png", "mimeType": "image/png", "sizes": ["512x512"] },
     { "src": "https://glif.app/favicon.svg", "mimeType": "image/svg+xml", "sizes": ["any"] }


### PR DESCRIPTION
GitHub Copilot's registry review rejected us: their automation reads the repo directly from the registry entry, and ours had no `repository` field. Adds it (pointing here), bumps to 1.0.1 since registry versions are immutable, and adds a short Tools paragraph to the README so it says what the server actually does on Copilot's display surfaces — deliberately not a per-tool table, since the real list lives in a private repo and a copy here would rot.

Merging isn't enough — publishing needs a `v1.0.1` tag to fire `publish.yml`.